### PR TITLE
Change ConfirmationStatus field on Sightings to an enum

### DIFF
--- a/backend/Migrations/20221012131940_ChangeConfirmationStatusToEnum.Designer.cs
+++ b/backend/Migrations/20221012131940_ChangeConfirmationStatusToEnum.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WhaleSpotting;
@@ -11,9 +12,10 @@ using WhaleSpotting;
 namespace WhaleSpotting.Migrations
 {
     [DbContext(typeof(WhaleSpottingDbContext))]
-    partial class WhaleSpottingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221012131940_ChangeConfirmationStatusToEnum")]
+    partial class ChangeConfirmationStatusToEnum
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20221012131940_ChangeConfirmationStatusToEnum.cs
+++ b/backend/Migrations/20221012131940_ChangeConfirmationStatusToEnum.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace WhaleSpotting.Migrations
+{
+    public partial class ChangeConfirmationStatusToEnum : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Sightings_ConfirmationStatuses_ConfirmationStatusId",
+                table: "Sightings");
+
+            migrationBuilder.DropTable(
+                name: "ConfirmationStatuses");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Sightings_ConfirmationStatusId",
+                table: "Sightings");
+
+            migrationBuilder.DropColumn(
+                name: "ConfirmationStatusId",
+                table: "Sightings");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ConfirmationStatus",
+                table: "Sightings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ConfirmationStatus",
+                table: "Sightings");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ConfirmationStatusId",
+                table: "Sightings",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ConfirmationStatuses",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Description = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConfirmationStatuses", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sightings_ConfirmationStatusId",
+                table: "Sightings",
+                column: "ConfirmationStatusId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Sightings_ConfirmationStatuses_ConfirmationStatusId",
+                table: "Sightings",
+                column: "ConfirmationStatusId",
+                principalTable: "ConfirmationStatuses",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/backend/Models/Database/ConfirmationStatus.cs
+++ b/backend/Models/Database/ConfirmationStatus.cs
@@ -1,8 +1,9 @@
 namespace WhaleSpotting.Models.Database
 {
-    public class ConfirmationStatus
+    public enum ConfirmationStatus
     {
-        public int Id { get; set; }
-        public string Description { get; set; }
+        Pending,
+        Rejected,
+        Approved
     }
 }

--- a/backend/WhaleSpottingDbContext.cs
+++ b/backend/WhaleSpottingDbContext.cs
@@ -7,7 +7,6 @@ namespace WhaleSpotting
 {
     public class WhaleSpottingDbContext : DbContext
     {
-        public DbSet<ConfirmationStatus> ConfirmationStatuses { get; set; }
         public DbSet<ConservationStatus> ConservationStatuses { get; set; }
         public DbSet<Location> Locations { get; set; }
         public DbSet<Sighting> Sightings { get; set; }


### PR DESCRIPTION
Change the field `ConfirmationStatus` on the `Sighting` class to be an enum instead of a separately stored database table. This will allow for hard-coding of the "pending", "rejected", and "accepted" values when retrieving sightings from the database.